### PR TITLE
Update `requests` for CVE-2018-18074

### DIFF
--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,2 +1,2 @@
 azure-storage==0.36.0
-requests==2.18.4
+requests==2.20.0


### PR DESCRIPTION
Details: https://nvd.nist.gov/vuln/detail/CVE-2018-18074

We don't use the the HTTP Authorization header in the sample, but upgrade the dependency to protect users who might fork the script.