### PR TITLE
Check for `bash` shell, emphasize usage in docs

### DIFF
--- a/bash/README.md
+++ b/bash/README.md
@@ -17,6 +17,7 @@ exhaustive error handling, &c.
 The following dependencies are likely already installed on your system, but
 worth noting:
 
+- `bash` shell
 - `curl`
 - `scp`
 - `ssh`
@@ -37,7 +38,9 @@ sudo apt install curl jq sshpass
 ## Script Steps
 
 To run the script against the sample fuzz target, set the `$ACCOUNT_ID` and
-`$API_TOKEN` script variables, then invoke `./msrd.sh`.
+`$API_TOKEN` script variables, then invoke `./msrd.sh` or `bash msrd.sh`.
+**Note:** invoking as `sh msrd.sh` will typically fail, as this script uses
+features specific to the `bash` shell.
 
 The script then attempts to:
 

--- a/bash/msrd.sh
+++ b/bash/msrd.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-set -e -o pipefail
 
+# Check if the user is invoking the script under `bash`, vs. e.g. `sh`.
+if [ -z "${BASH_VERSION}" ]; then
+  echo 'ERROR: not using `bash` shell\n' >&2
+  echo 'This script uses features specific to the `bash` shell.\n' >&2
+  echo 'Please run this script using `bash msrd.sh` or `./msrd.sh`.' >&2
+  exit 1
+fi
+
+# Fail fast on errors.
+set -e -o pipefail
 
 # Base origin of the MSRD environment in use, here set to production.
 readonly MSRD_ORIGIN='https://www.microsoftsecurityriskdetection.com'


### PR DESCRIPTION
The `bash` example really is that: a  `bash` script, and will not work via `sh msrd.sh` unless `sh` is symlinked to `bash`.

1. Check if the user is invoking the script via `bash`, and exit with a friendly error message if not.
2. Update docs to emphasize usage of `bash`, and note that `sh` alone won't usually work.