### PR TITLE
Change seed to crash with +1 bytebybyte fuzz strategy

### DIFF
--- a/SampleFuzzingJobs/InPlaceFuzzing/Seeds/seed1.top
+++ b/SampleFuzzingJobs/InPlaceFuzzing/Seeds/seed1.top
@@ -1,1 +1,1 @@
-POLO,POLO,2,seed1.re1,seed1.re2,
+POLO,XOLO,2,seed1.re1,seed1.re2,


### PR DESCRIPTION
For our BVT, this change *should* ensure we detect and report the bug very quickly after fuzzing starts.