### PR TITLE
Don't hardcode OS image ID in sample job

### DIFF
--- a/Python/job-data/demofuzz.json
+++ b/Python/job-data/demofuzz.json
@@ -1,6 +1,9 @@
 {
     "name": "demofuzz",
-    "osImageId": "21539f82-8ed1-4e04-8b65-c4dac5eae289",
+    "osType": "Linux",
+    "osEdition": "Redhat",
+    "osBuild": "7.2",
+    "osArchitecture": "x64",
     "tier": "Standard",
     "setup": {
         "package": {


### PR DESCRIPTION
OS image IDs aren't stable across environments. Instead, fully specify the OS image using properties that are stable.

Closes #30 